### PR TITLE
fix: 비밀번호 아이콘 toggle 수정

### DIFF
--- a/src/pages/signUp/index.html
+++ b/src/pages/signUp/index.html
@@ -14,25 +14,25 @@
           <form action="#" method="post">
               <label for="user-id" class="sr-only">아이디</label>
               <input type="text" id="user-id" name="user-id" placeholder="아이디 " required>
-              <span class="delete-icon invisible"><img src="/public/icon/signUp/iconDelete.svg" alt="입력 삭제"></span>
+              <span class="delete-icon invisible"><img src="/icon/signUp/iconDelete.svg" alt="입력 삭제"></span>
               <p class="input-subtext">영문 또는 영문, 숫자 조합 6~12자리</p>
   
             <label for="user-pw" class="sr-only">비밀번호</label>
             <input type="password" id="user-pw" name="user-pw" placeholder="비밀번호" required>
-            <span class="delete-icon delete-pw invisible"><img src="/public/icon/signUp/iconDelete.svg" alt="입력 삭제"></span>
+            <span class="delete-icon delete-pw invisible"><img src="/icon/signUp/iconDelete.svg" alt="입력 삭제"></span>
             <p class="input-subtext">영문, 숫자, 특수문자(~!@#$%^&*) 조합 8~15자리</p>
-            <span class="password-toggle-icon pw-visible"><img src="/public/icon/signUp/iconWatching.svg" alt="입력된 비밀번호 보기"></span>
+            <span class="password-toggle-icon pw-visible"><img src="/icon/signUp/iconWatching.svg" alt="입력된 비밀번호 보기"></span>
 
             
             <label for="confirm-password" class="sr-only">비밀번호 확인</label>
             <input type="password" id="confirm-password" name="confirm-password" placeholder="비밀번호 확인" required>
-            <span class="delete-icon delete-pw invisible"><img src="/public/icon/signUp/iconDelete.svg" alt="입력 삭제"></span>
+            <span class="delete-icon delete-pw invisible"><img src="/icon/signUp/iconDelete.svg" alt="입력 삭제"></span>
             <p class="input-subtext">&nbsp;</p>
-            <span class="password-toggle-icon comfirm-pw-visible"><img src="/public/icon/signUp/iconWatching.svg" alt="입력된 비밀번호 보기"></span>
+            <span class="password-toggle-icon comfirm-pw-visible"><img src="/icon/signUp/iconWatching.svg" alt="입력된 비밀번호 보기"></span>
               
               <label for="email" class="sr-only">이메일</label>
               <input type="email" id="email" name="email" placeholder="이메일" required>
-              <span class="delete-icon invisible"><img src="/public/icon/signUp/iconDelete.svg" alt="입력 삭제"></span>
+              <span class="delete-icon invisible"><img src="/icon/signUp/iconDelete.svg" alt="입력 삭제"></span>
               <p class="input-subtext"></p>
               
               <div class="privacy-policy">

--- a/src/pages/signUp/index.html
+++ b/src/pages/signUp/index.html
@@ -21,14 +21,14 @@
             <input type="password" id="user-pw" name="user-pw" placeholder="비밀번호" required>
             <span class="delete-icon delete-pw invisible"><img src="/public/icon/signUp/iconDelete.svg" alt="입력 삭제"></span>
             <p class="input-subtext">영문, 숫자, 특수문자(~!@#$%^&*) 조합 8~15자리</p>
-            <span class="password-toggle-icon"><img src="/public/icon/signUp/iconWatching.svg" alt="입력된 비밀번호 보기"></span>
+            <span class="password-toggle-icon pw-visible"><img src="/public/icon/signUp/iconWatching.svg" alt="입력된 비밀번호 보기"></span>
 
             
             <label for="confirm-password" class="sr-only">비밀번호 확인</label>
             <input type="password" id="confirm-password" name="confirm-password" placeholder="비밀번호 확인" required>
             <span class="delete-icon delete-pw invisible"><img src="/public/icon/signUp/iconDelete.svg" alt="입력 삭제"></span>
             <p class="input-subtext">&nbsp;</p>
-            <span class="password-toggle-icon"><img src="/public/icon/signUp/iconWatching.svg" alt="입력된 비밀번호 보기"></span>
+            <span class="password-toggle-icon comfirm-pw-visible"><img src="/public/icon/signUp/iconWatching.svg" alt="입력된 비밀번호 보기"></span>
               
               <label for="email" class="sr-only">이메일</label>
               <input type="email" id="email" name="email" placeholder="이메일" required>

--- a/src/pages/signUp/signUp.js
+++ b/src/pages/signUp/signUp.js
@@ -52,26 +52,45 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 });
 
-function togglePasswordVisibility(element) {
-  const input = element.previousElementSibling;
-  input.classList.toggle('active');
 
-  if (input.classList.contains('active')) {
+function togglePasswordVisibility(element) {
+  const pwInput = getNode("#user-pw");
+  pwInput.classList.toggle('active');
+
+  if (pwInput.classList.contains('active')) {
     element.querySelector('img').src = '/public/icon/signUp/iconWatched.svg';
-    input.setAttribute('type', 'text');
+    pwInput.setAttribute('type', 'text');
   } else {
     element.querySelector('img').src = '/public/icon/signUp/iconWatching.svg';
-    input.setAttribute('type', 'password');
+    pwInput.setAttribute('type', 'password');
   }
 }
 
-// HTML에서 toggle button과 연결된 아이콘 및 input 설정
-const toggleButtons = document.querySelectorAll('.password-toggle-icon');
-toggleButtons.forEach((button) => {
-  button.addEventListener('click', function () {
+function toggleConfirmPasswordVisibility(element){
+  const confirmPwInput = getNode("#confirm-password");
+  confirmPwInput.classList.toggle('active');
+
+  if (confirmPwInput.classList.contains('active')) {
+    element.querySelector('img').src = '/public/icon/signUp/iconWatched.svg';
+    confirmPwInput.setAttribute('type', 'text');
+  } else {
+    element.querySelector('img').src = '/public/icon/signUp/iconWatching.svg';
+    confirmPwInput.setAttribute('type', 'password');
+  }
+}
+
+document.querySelectorAll('.pw-visible').forEach(icon => {
+  icon.addEventListener('click', function() {
     togglePasswordVisibility(this);
   });
 });
+
+document.querySelectorAll('.comfirm-pw-visible').forEach(icon => {
+  icon.addEventListener('click', function() {
+    toggleConfirmPasswordVisibility(this);
+  })
+})
+
 
 async function handleSignUp(event) {
   event.preventDefault();

--- a/src/pages/signUp/signUp.js
+++ b/src/pages/signUp/signUp.js
@@ -58,10 +58,10 @@ function togglePasswordVisibility(element) {
   pwInput.classList.toggle('active');
 
   if (pwInput.classList.contains('active')) {
-    element.querySelector('img').src = '/public/icon/signUp/iconWatched.svg';
+    element.querySelector('img').src = '/icon/signUp/iconWatched.svg';
     pwInput.setAttribute('type', 'text');
   } else {
-    element.querySelector('img').src = '/public/icon/signUp/iconWatching.svg';
+    element.querySelector('img').src = '/icon/signUp/iconWatching.svg';
     pwInput.setAttribute('type', 'password');
   }
 }
@@ -71,10 +71,10 @@ function toggleConfirmPasswordVisibility(element){
   confirmPwInput.classList.toggle('active');
 
   if (confirmPwInput.classList.contains('active')) {
-    element.querySelector('img').src = '/public/icon/signUp/iconWatched.svg';
+    element.querySelector('img').src = '/icon/signUp/iconWatched.svg';
     confirmPwInput.setAttribute('type', 'text');
   } else {
-    element.querySelector('img').src = '/public/icon/signUp/iconWatching.svg';
+    element.querySelector('img').src = '/icon/signUp/iconWatching.svg';
     confirmPwInput.setAttribute('type', 'password');
   }
 }

--- a/src/styles/signUp.scss
+++ b/src/styles/signUp.scss
@@ -260,6 +260,10 @@ button.sign-up {
         font-size: 1.3rem;
         height: 5.38rem;
     }
+    &:hover{
+        background-color: $--brand-red-1;
+        color: $--white;
+    }
 }
 
 // 체크박스 숨기기


### PR DESCRIPTION
# PR 서식

- PR 이름 : 회원가입 페이지 비밀번호 아이콘 toggle 작동 수정

- 수정한 이슈: #40 

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.

### PR 상세(활동 및 수정사항)

- 선우님이 말씀해주신대로 const pwInput = getNode("#user-pw")로 input 영역을 확정한 후 수정하였더니 제대로 작동하는 것을 확인하였습니다!
- 하지만 password와 confirm-password 란이 묶여서 작동하는것을 확인, 각 icon을 감싸는 span에 class를 하나씩 더 부여하고 조건문을 각각 지정해주었더니 따로따로 잘 작동하는 것 확인하였습니당
